### PR TITLE
Fix simple build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.6-alpine3.10 as builder
+FROM python:3.7-alpine3.10 as builder
 
 RUN apk --no-cache upgrade && apk --no-cache add build-base tar musl-utils openssl-dev && pip3 install --upgrade pip
-RUN pip3 install setuptools appdirs packaging cx_Freeze==6.0b1
+RUN pip3 install setuptools appdirs packaging cx_Freeze
 
 COPY . .
 RUN ln -s /lib/libc.musl-x86_64.so.1 ldd
@@ -11,10 +11,11 @@ RUN python3 setup.py build_exe
 
 FROM alpine:3.10
 RUN apk --no-cache upgrade && apk --no-cache add wget libffi expat
-COPY --from=builder build/exe.linux-x86_64-3.6 /graviteeio/
-RUN mkdir /graviteeio/config
+COPY --from=builder build/exe.linux-x86_64-3.7 /graviteeio/
+RUN mkdir /graviteeio/config && chown -R nobody:nobody /graviteeio
 USER nobody:nobody
 ENV LC_ALL=en_US.utf8
+ENV LD_LIBRARY_PATH=/graviteeio/lib
 ENV GRAVITEEIO_CONF_FILE=/graviteeio/config/.graviteeio
 VOLUME [ "/graviteeio/config/" ]
 ENTRYPOINT ["/graviteeio/gio"]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from graviteeio_cli.__version__ import __version__
 
 
 this_dir = abspath(dirname(__file__))
-with open(join(this_dir, 'README.md'), encoding='utf-8') as file:
+with open(join(this_dir, 'README.adoc'), encoding='utf-8') as file:
     long_description = file.read()
 
 


### PR DESCRIPTION
This merge request fixes some simple build issues with current master:

  * `setup.py` fails because it depends on README.md that has been converted to README.adoc

  * the binary client in Dockerfile doesn't return any output on `docker run -it gio apim apis ps`. 

I couldn't find a way to make the binary work with Python-3.6 but it works fine with Python-3.7.